### PR TITLE
New Action Plugins for OcNOS committed by Sharath Samanth

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,5 +85,31 @@ ocnos_bgp_facts collects information about BGP. Currently, this modules only sup
 ## ocnos_isis_facts
 ocnos_isis_facts collects information about ISIS. Currently, this modules only supports ISIS neighbor.
 
+## ocnos_config_backup
+Action Plugin that copies OcNOS Running Configuration into a remote location.
+
+## ocnos_config_restore
+Action Plugin that copies a configuration file from remote location to OcNOS Startup configuration.
+
+## ocnos_pcap
+Action Plugin that Captures OcNOS Interface's control plane packets and copy into remote location.
+
+## ocnos_sw_update
+Action Plugin that updates the OcNOS Software using sys-update http method.
+
+## ocnos_core_extract
+Action Plugin that extracts crash files (Cores) and exports the GDB Log into remote location.
+
+## ocnos_ts_extract
+Action Plugin that extracts OcNOS TechSupport files and exports into remote location.
+
+## ocnos_iperf3
+Action Plugin that enables IPERF3 on OcNOS Devices either as a server or as a client.
+This plugin is strictly for testing purposes and not recommended for Production Deployments.
+OcNOS Rate Limits the CPU packets to 20Mbps
+
+## ocnos_validate
+Action Plugin that compares the Actual Output and the Expected Output of OcNOS Show commands.
+
 
 Please refer to the IPI provided documentation available at https://documentation.ipinfusion.com/home/Content/LibraryPages/Library.htm for more detail.

--- a/ipinfusion/ocnos/README.md
+++ b/ipinfusion/ocnos/README.md
@@ -98,10 +98,39 @@ ocnos_bgp_facts collects information about BGP. Currently, this modules supports
 ## ocnos_isis_facts
 ocnos_isis_facts collects information about ISIS. Currently, this modules supports only ISIS neighbor.
 
+## ocnos_config_backup
+Action Plugin that copies OcNOS Running Configuration into a remote location.
+
+## ocnos_config_restore
+Action Plugin that copies a configuration file from remote location to OcNOS Startup configuration.
+
+## ocnos_pcap
+Action Plugin that Captures OcNOS Interface's control plane packets and copy into remote location.
+
+## ocnos_sw_update
+Action Plugin that updates the OcNOS Software using sys-update http method.
+
+## ocnos_core_extract
+Action Plugin that extracts crash files (Cores) and exports the GDB Log into remote location.
+
+## ocnos_ts_extract
+Action Plugin that extracts OcNOS TechSupport files and exports into remote location.
+
+## ocnos_iperf3
+Action Plugin that enables IPERF3 on OcNOS Devices either as a server or as a client.
+This plugin is strictly for testing purposes and not recommended for Production Deployments.
+OcNOS Rate Limits the CPU packets to 20Mbps
+
+## ocnos_validate
+Action Plugin that compares the Actual Output and the Expected Output of OcNOS Show commands.
 
 Please refer the IPI provided documents for the detail.
 
 # Version history
+- 1.2.5
+  - OcNOS Action Plugins for SW Update, Configuration Backup and Restore, TechSupport Copy, Packet Capture
+- 1.2.4
+  - OcNOS Facts Module Error Handling
 - 1.2.3
   - Avoid error when ocnos_facts is used with ansible_pylibssh
 - 1.2.2

--- a/ipinfusion/ocnos/galaxy.yml
+++ b/ipinfusion/ocnos/galaxy.yml
@@ -2,7 +2,7 @@
 
 namespace: "ipinfusion"
 name: "ocnos"
-version: "1.2.3"
+version: "1.2.5"
 readme: "README.md"
 
 authors:

--- a/ipinfusion/ocnos/plugins/action/ocnos_config_restore.py
+++ b/ipinfusion/ocnos/plugins/action/ocnos_config_restore.py
@@ -1,0 +1,135 @@
+# Copyright (C) 2025 IP Infusion
+#
+# GNU General Public License v3.0+
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+#
+# Contains Action Plugin methods for OcNOS Configuration Restore Module
+# IP Infusion
+#
+
+from ansible.plugins.action import ActionBase
+from ansible.errors import AnsibleError
+from ansible.utils.display import Display
+from datetime import datetime
+import re
+import time
+from netmiko import ConnectHandler
+from paramiko.proxy import ProxyCommand
+
+display = Display()
+
+class ActionModule(ActionBase):
+    def run(self, tmp=None, task_vars=None):
+        
+        inventory_hostname = task_vars.get('inventory_hostname')
+
+        required_args = ['remote_host', 'remote_path', 'remote_username', 'remote_password','cfg_file']
+        missing_args = [arg for arg in required_args if self._task.args.get(arg) is None]
+
+        if missing_args:
+            raise AnsibleError(f"Missing required arguments: {', '.join(missing_args)}")
+
+        # Get the remote server details from the Playbook
+        remote_host = self._task.args.get('remote_host')
+        remote_path = self._task.args.get('remote_path')
+        remote_username = self._task.args.get('remote_username')
+        remote_password = self._task.args.get('remote_password')
+        node_type = self._task.args.get('node_type','physical')
+        trans = self._task.args.get('transport','scp')
+        config_file = self._task.args.get('cfg_file')
+
+        if trans == 'scp' or trans =='ftp':
+            pass
+        else:
+            raise AnsibleError("Module only supports ftp or scp transport types")
+        
+        # Extract OcNOS connection details from inventory
+        host = self._task.args.get('ansible_host') or task_vars.get('ansible_host')
+        username = self._task.args.get('ansible_ssh_user') or task_vars.get('ansible_ssh_user')
+        password = self._task.args.get('ansible_ssh_pass') or task_vars.get('ansible_ssh_pass')
+        port = str(self._task.args.get('ansible_port') or task_vars.get('ansible_port') or 22)
+        
+        connection_dict = {
+            'host': host,
+            'username': username,
+            'password': password,
+            'device_type': 'ipinfusion_ocnos'
+            }
+            
+        if not all(connection_dict.values()):
+            raise AnsibleError("Missing OcNOS connection details in inventory/task vars.")
+
+        #Handle SSH Proxy or Jump Server Setting
+        proxy_cmd = (
+                self._task.args.get('ansible_ssh_common_args')
+                or task_vars.get('ansible_ssh_common_args')
+        )
+
+        if proxy_cmd:
+             proxy_cmd = proxy_cmd.strip()
+             if proxy_cmd.startswith("-o ProxyCommand="):
+                 # Remove the prefix
+                 proxy_cmd = proxy_cmd.replace("-o ProxyCommand=", "", 1).strip()
+                 # Strip surrounding quotes
+                 proxy_cmd = proxy_cmd.strip('"').strip("'")
+             # Replace %h and %p placeholders with actual host/port
+             proxy_cmd = proxy_cmd.replace("%h", host).replace("%p", port)
+             connection_dict['sock'] = ProxyCommand(proxy_cmd)
+
+        result = {'changed': False, 'Reboot_String': '' , 'string_op': '','failed': False}
+        output_status = []
+        string_op = ''
+        state=1
+        
+        try:
+            # Try to establish a connection to the DUT using netmiko 
+            session = ConnectHandler(**connection_dict)
+            
+            #Enter into Debian Linux
+            session.enable()
+            
+            if node_type == 'vm':
+                copy_cmd = f'copy {trans} {trans}://{remote_username}:{remote_password}@{remote_host}{remote_path}/{config_file} startup-config'
+            else:
+                copy_cmd = f'copy {trans} {trans}://{remote_username}:{remote_password}@{remote_host}{remote_path}/{config_file} startup-config vrf management'
+            output = session.send_command(copy_cmd, expect_string='#', read_timeout=60)
+            output_status.append(output)
+            if "Copy Success" in output or "copy success" in output.lower():
+                state = 0
+            
+            if state:
+                raise AnsibleError(f"Copy failed for {config_file}: {output}")    
+            else:
+                result['changed'] = True
+        
+            string_op += output_status[0]
+            result['string_op'] = string_op
+
+            output = session.send_command_timing('reload')
+            if 'Would you like' in output:
+                session.send_command_timing('n')
+                session.send_command_timing('y')
+            else:
+                session.send_command_timing('y')
+
+            try:
+                if session.is_alive():
+                    result['Reboot_string'] = 'Device Failed to Reboot'
+                else:
+                    result['Reboot_String'] = 'Device Rebooted Successfully'
+            except Exception as e:
+                if "Broken pipe" in str(e):
+                    result['Reboot_String'] = 'Device Rebooted Successfully (proxy closed)'
+                else:
+                    raise AnsibleError(f"OcNOS Configuration Restore failed: {str(e)}")
+
+        
+        except Exception as e:
+            raise AnsibleError(f"OcNOS Configuration Restore failed: {str(e)}")
+        return result 

--- a/ipinfusion/ocnos/plugins/action/ocnos_core_extract.py
+++ b/ipinfusion/ocnos/plugins/action/ocnos_core_extract.py
@@ -1,0 +1,127 @@
+# Copyright (C) 2019 IP Infusion
+#
+# GNU General Public License v3.0+
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+#
+# Contains Action Plugin methods for OcNOS Core File extraction Module
+# IP Infusion
+#
+
+from ansible.plugins.action import ActionBase
+from ansible.errors import AnsibleError
+from ansible.utils.display import Display
+import re
+import time
+from netmiko import ConnectHandler
+from paramiko.proxy import ProxyCommand
+
+display = Display()
+
+class ActionModule(ActionBase):
+    def run(self, tmp=None, task_vars=None):
+        # Collect task arguments
+        remote_host = self._task.args.get('remote_host')
+        remote_path = self._task.args.get('remote_path')
+        remote_username = self._task.args.get('remote_username')
+        remote_password = self._task.args.get('remote_password')
+        node_type = self._task.args.get('node_type','physical')
+        trans = self._task.args.get('transport','scp')
+
+        if trans == 'scp' or trans =='ftp':
+            pass
+        else:
+            raise AnsibleError("Module only supports ftp or scp transport types")
+
+        # Extract OcNOS connection details from inventory
+        host = self._task.args.get('ansible_host') or task_vars.get('ansible_host')
+        username = self._task.args.get('ansible_ssh_user') or task_vars.get('ansible_ssh_user')
+        password = self._task.args.get('ansible_ssh_pass') or task_vars.get('ansible_ssh_pass')
+        port = str(self._task.args.get('ansible_port') or task_vars.get('ansible_port') or 22)
+        inventory_hostname = task_vars.get('inventory_hostname')
+
+        connection_dict = {
+            'host': host,
+            'username': username,
+            'password': password,
+            'device_type': 'ipinfusion_ocnos'
+        }
+
+        if not all(connection_dict.values()):
+            raise AnsibleError("Missing OcNOS connection details in inventory/task vars.")
+
+        result = {'changed': False, 'copied_files': [], 'copy_stats': '', 'failed': False}
+
+        #Handle SSH Proxy or Jump Server Setting
+        proxy_cmd = (
+                self._task.args.get('ansible_ssh_common_args')
+                or task_vars.get('ansible_ssh_common_args')
+        )
+
+        if proxy_cmd:
+            proxy_cmd = proxy_cmd.strip()
+
+            if proxy_cmd.startswith("-o ProxyCommand="):
+                # Remove the prefix
+                proxy_cmd = proxy_cmd.replace("-o ProxyCommand=", "", 1).strip()
+                # Strip surrounding quotes
+                proxy_cmd = proxy_cmd.strip('"').strip("'")
+
+            # Replace %h and %p placeholders with actual host/port
+            proxy_cmd = proxy_cmd.replace("%h", host).replace("%p", port)
+
+            connection_dict['sock'] = ProxyCommand(proxy_cmd)
+
+        try:
+            conn = ConnectHandler(**connection_dict)
+            conn.enable()
+
+            core_output = conn.send_command('show cores')
+            core_files = re.findall(r'core_.*', core_output)
+
+            if not core_files:
+                result['msg'] = "No core files found"
+                return result
+
+            core_file_logs = []
+            for file in core_files:
+                details_output = conn.send_command(f'show core {file} details', read_timeout=60)
+                match = re.search(r'core_.*', details_output)
+                if match:
+                    core_file_logs.append(match.group())
+                    #display.display(f'appended {match.group()} to core log list')
+                    time.sleep(120)
+                    dest_filename = f"{inventory_hostname}_{match.group()}"
+                    if node_type == 'vm':
+                        copy_cmd = (
+                            f"copy filepath /tmp/{match.group()} "
+                            f"{trans} {trans}://{remote_username}:{remote_password}@{remote_host}{remote_path}/{dest_filename}"
+                        )
+                    else:
+                        copy_cmd = (
+                            f"copy filepath /tmp/{match.group()} "
+                            f"{trans} {trans}://{remote_username}:{remote_password}@{remote_host}{remote_path}/{dest_filename} vrf management"
+                        )
+                    #display.display(f'the copy command is {copy_cmd}')
+                    output = conn.send_command(copy_cmd)
+                    #display.display(output)
+                    time.sleep(10)
+
+                    if "Copy Success" in output or "copy success" in output.lower():
+                        result['copied_files'].append(dest_filename)
+                        result['copy_stats'] += output
+                        result['core_file_location'] = f'{remote_path}@{remote_host}'
+                        result['changed'] = True
+                    else:
+                        raise AnsibleError(f"Copy failed for {core_file}: {output}")
+
+        except Exception as e:
+            raise AnsibleError(f"OcNOS core extraction failed: {str(e)}")
+
+        conn.send_command('clear cores')
+        return result

--- a/ipinfusion/ocnos/plugins/action/ocnos_iperf3.py
+++ b/ipinfusion/ocnos/plugins/action/ocnos_iperf3.py
@@ -1,0 +1,129 @@
+# Copyright (C) 2019 IP Infusion
+#
+# GNU General Public License v3.0+
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+#
+# Contains Action Plugin methods for OcNOS IPERF3 Module
+# IP Infusion
+#
+
+from ansible.plugins.action import ActionBase
+from ansible.errors import AnsibleActionFail
+from ansible.utils.display import Display
+from netmiko import ConnectHandler
+import time
+import re
+import paramiko
+from paramiko.proxy import ProxyCommand
+
+display = Display()
+
+class ActionModule(ActionBase):
+
+    def run(self, tmp=None, task_vars=None):
+        result = super().run(tmp, task_vars)
+        cmd = self._task.args.get('cmd')
+
+        if not cmd:
+            raise AnsibleActionFail("Missing required argument: cmd")
+
+        # Get connection data from inventory
+        host = self._task.args.get('ansible_host') or task_vars.get('ansible_host')
+        username = self._task.args.get('ansible_ssh_user', 'ocnos') or task_vars.get('ansible_ssh_user')
+        password = self._task.args.get('ansible_ssh_pass', 'ocnos') or task_vars.get('ansible_ssh_pass')
+        port = str(self._task.args.get('ansible_port') or task_vars.get('ansible_port') or 22)
+        device_type = 'ipinfusion_ocnos'
+
+        if not host:
+            raise AnsibleActionFail("Missing 'ansible_host' in inventory for the target")
+
+        # Prepare connection
+        conn = dict(
+            host=host,
+            username=username,
+            password=password,
+            device_type=device_type,
+        )
+
+        # Handle jump host (ansible_ssh_common_args → ProxyCommand)
+        proxy_cmd = (
+            self._task.args.get('ansible_ssh_common_args')
+            or task_vars.get('ansible_ssh_common_args')
+        )
+        if proxy_cmd:
+            proxy_cmd = proxy_cmd.strip()
+
+            if proxy_cmd.startswith("-o ProxyCommand="):
+                # Remove the prefix
+                proxy_cmd = proxy_cmd.replace("-o ProxyCommand=", "", 1).strip()
+                # Strip surrounding quotes
+                proxy_cmd = proxy_cmd.strip('"').strip("'")
+
+            # Replace %h and %p placeholders with actual host/port
+            proxy_cmd = proxy_cmd.replace("%h", host).replace("%p", port)
+
+            conn['sock'] = ProxyCommand(proxy_cmd)
+
+        try:
+            device = ConnectHandler(**conn)
+            device.enable()
+
+            # Enter shell
+            device.send_command('start-shell', expect_string=r'\$')
+            time.sleep(1)
+            device.send_command('su -', expect_string='Password:')
+            device.send_command('root', expect_string=r'#')
+
+            # kill command if nothing given
+            try:
+                cmd.split()[1]
+            except:
+                cmd = "kill -9 `ps aux | grep iperf | grep -v grep | awk '{print $2}'`"
+
+            # Server mode: run in background
+            if '-s' in cmd.split():
+                cmd = f'nohup {cmd} >/dev/null 2>/dev/null &'
+
+            # get the timer pattern from the iperf3 cmd to adjust the read_timeout
+            timer_pattern = re.compile(r'-t\s\d+')
+            try:
+                if re.findall(timer_pattern, cmd)[0].split()[1]:
+                    timeout = int(re.findall(timer_pattern, cmd)[0].split()[1])
+                    timeout += 10  # tolerance
+            except:
+                timeout = 30
+
+            iperf_output = device.send_command(cmd, expect_string=r'#', read_timeout=timeout)
+            device.disconnect()
+
+            result['cmd'] = cmd
+            clean_output = re.sub(r'\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])', '', iperf_output)
+            result['output'] = clean_output.strip().splitlines()
+
+            if 'nohup' in cmd:
+                result['changed'] = True
+                return result
+
+            if 'iperf Done.' in iperf_output:
+                result['changed'] = True
+                result['success'] = True
+            elif 'iperf3' in iperf_output:
+                result['changed'] = True
+                result['success'] = False
+                result['failed'] = True
+            else:
+                result['changed'] = True
+                result['success'] = True
+
+        except Exception as e:
+            result['failed'] = True
+            result['msg'] = f"Failed to run iperf3 {e}"
+
+        return result
+

--- a/ipinfusion/ocnos/plugins/action/ocnos_sw_update.py
+++ b/ipinfusion/ocnos/plugins/action/ocnos_sw_update.py
@@ -1,0 +1,141 @@
+# Copyright (C) 2019 IP Infusion
+#
+# GNU General Public License v3.0+
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+#
+# Contains Action Plugin methods for OcNOS Software Update Module
+# IP Infusion
+#
+
+from ansible.plugins.action import ActionBase
+from ansible.errors import AnsibleError
+from ansible.utils.display import Display
+from datetime import datetime
+import re
+import time
+from netmiko import ConnectHandler
+from paramiko.proxy import ProxyCommand
+
+display = Display()
+
+class ActionModule(ActionBase):
+    def run(self, tmp=None, task_vars=None):
+        
+        inventory_hostname = task_vars.get('inventory_hostname')
+
+        required_args = ['update_url']
+        missing_args = [arg for arg in required_args if self._task.args.get(arg) is None]
+
+        if missing_args:
+            raise AnsibleError(f"Missing required arguments: {', '.join(missing_args)}")
+
+        update_url = self._task.args.get('update_url')
+        #if no name-server is provided, use the ipinfusion default.
+        name_server = self._task.args.get('name_server','10.16.10.23')
+
+        # Extract OcNOS connection details from inventory
+        host = self._task.args.get('ansible_host') or task_vars.get('ansible_host')
+        username = self._task.args.get('ansible_ssh_user') or task_vars.get('ansible_ssh_user')
+        password = self._task.args.get('ansible_ssh_pass') or task_vars.get('ansible_ssh_pass')
+        port = str(self._task.args.get('ansible_port') or task_vars.get('ansible_port') or 22)
+        
+        connection_dict = {
+            'host': host,
+            'username': username,
+            'password': password,
+            'device_type': 'ipinfusion_ocnos'
+            }
+
+        #Handle SSH Proxy or Jump Server Setting
+        proxy_cmd = (
+                self._task.args.get('ansible_ssh_common_args')
+                or task_vars.get('ansible_ssh_common_args')
+        )
+        if proxy_cmd:
+             proxy_cmd = proxy_cmd.strip()
+             if proxy_cmd.startswith("-o ProxyCommand="):
+                 # Remove the prefix
+                 proxy_cmd = proxy_cmd.replace("-o ProxyCommand=", "", 1).strip()
+                 # Strip surrounding quotes
+                 proxy_cmd = proxy_cmd.strip('"').strip("'")
+             # Replace %h and %p placeholders with actual host/port
+             proxy_cmd = proxy_cmd.replace("%h", host).replace("%p", port)
+             connection_dict['sock'] = ProxyCommand(proxy_cmd)
+            
+        if not all(connection_dict.values()):
+            raise AnsibleError("Missing OcNOS connection details in inventory/task vars.")
+
+        result = {'changed': False, 'Update_String': '' ,'failed': False}
+        
+        try:
+            # Try to establish a connection to the DUT using netmiko 
+            session = ConnectHandler(**connection_dict)
+            
+            #Enter into Debian Linux
+            session.enable()
+            session.send_config_set([f'ip name-server vrf management {name_server}','commit'])
+            session.send_command('copy run start',read_timeout=60)
+            #Clean up the /installers to make room for new images
+            installer_list = session.send_command('show installers')
+            if installer_list:
+                installer_list = session.send_command('show installers').split('\n')
+                image_list = [ i.split('/')[2] for i in installer_list ]
+                if len(image_list) > 2:
+                    for images in image_list:
+                        session.send_command(f'sys-update delete {images}')
+                        time.sleep(2)
+            update_command = f'sys-update install source-interface eth0 {update_url}'
+            output = session.send_command_timing(update_command)
+            output = session.send_command_timing('y')
+            display.display(output)
+            # Below if condition is due to OcNOS DNS resolver timing issue.
+            #the condition is hit when only one working name-server entry is in ocnos
+            if 'Installer download failed' in output:
+                result['Update_String'] = f'Device Failed to upgrade because {output}'
+                raise AnsibleError(f"OcNOS Software Upgrade Failed {output}")
+            else:
+                output = session.send_command_timing('!')
+                #display.display(output)
+                if '%% Installer download failed' in output:
+                    display.display('Now I am here....')
+                    result['Update_String'] = f'Device Failed to upgrade because {output}'
+                    result['failed'] = True
+                    raise AnsibleError(f"OcNOS Software Upgrade Failed: {output}")
+                if '%% Device license is not compatible with new software' in output:
+                    temp_op = session.send_command_timing('n')
+                    result['Update_String'] = f'Device Failed to upgrade because of Software and License incompatibility'
+                    result['failed'] = True
+                    raise AnsibleError(f"OcNOS Software Upgrade Failed: {output}")
+                if '%% Software version you are trying to upgrade is already installed' in output:
+                    temp_op = session.send_command_timing('n')
+                    display.display('Software is already installed and the device will not reload')
+                    result['Update_String'] = f'Device Failed to upgrade as the software version is already installed'
+                    result['failed'] = True
+                    raise AnsibleError(f"OcNOS Software Upgrade Failed: Software version already installed.")
+            #wait for 75 seconds for sysupdate to reload the device   
+            display.display('Wait for 75 Seconds for sys-update to reload the device...')
+            time.sleep(75)
+            try:
+                if session.is_alive():
+                    display.display('Device failed to reload even after 60 seconds')
+                    result['update_string'] = f'Device failed to reload'
+                    raise AnsibleError(f"OcNOS Software Upgrade Failed:")
+                else:
+                    display.display('Device Upgraded and reload process started by sys-update')
+                    result['update_string'] = f'Device Upgraded and reloaded'
+            except Exception as e:
+                if "Broken pipe" in str(e):
+                    display.display('Device Upgraded and reload process started by sys-update')
+                    result['update_string'] = f'Device Upgraded and reloaded'
+                else:
+                    raise AnsibleError(f"OcNOS Software Upgrade Failed: {str(e)}")
+        
+        except Exception as e:
+            raise AnsibleError(f"OcNOS Software Upgrade Failed: {str(e)}")
+        return result

--- a/ipinfusion/ocnos/plugins/action/ocnos_ts_extract.py
+++ b/ipinfusion/ocnos/plugins/action/ocnos_ts_extract.py
@@ -1,0 +1,146 @@
+# Copyright (C) 2019 IP Infusion
+#
+# GNU General Public License v3.0+
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+#
+# Contains Action Plugin methods for OcNOS TechSupport Extraction Module
+# IP Infusion
+#
+
+from ansible.plugins.action import ActionBase
+from ansible.errors import AnsibleError
+from ansible.utils.display import Display
+import re
+import time
+from netmiko import ConnectHandler
+from paramiko.proxy import ProxyCommand
+
+display = Display()
+
+class ActionModule(ActionBase):
+    def run(self, tmp=None, task_vars=None):
+        
+        # Get the remote server details from the Playbook
+        remote_host = self._task.args.get('remote_host')
+        remote_path = self._task.args.get('remote_path')
+        remote_username = self._task.args.get('remote_username')
+        remote_password = self._task.args.get('remote_password')
+        node_type = self._task.args.get('node_type','physical')
+        
+        # Extract OcNOS connection details from inventory
+        host = self._task.args.get('ansible_host') or task_vars.get('ansible_host')
+        username = self._task.args.get('ansible_ssh_user') or task_vars.get('ansible_ssh_user')
+        password = self._task.args.get('ansible_ssh_pass') or task_vars.get('ansible_ssh_pass')
+        port = str(self._task.args.get('ansible_port') or task_vars.get('ansible_port') or 22)
+
+        connection_dict = {
+            'host': host,
+            'username': username,
+            'password': password,
+            'device_type': 'ipinfusion_ocnos'
+            }
+
+        #Handle SSH Proxy or Jump Server Setting
+        proxy_cmd = (
+                self._task.args.get('ansible_ssh_common_args')
+                or task_vars.get('ansible_ssh_common_args')
+        )
+
+        if proxy_cmd:
+             proxy_cmd = proxy_cmd.strip()
+             if proxy_cmd.startswith("-o ProxyCommand="):
+                 # Remove the prefix
+                 proxy_cmd = proxy_cmd.replace("-o ProxyCommand=", "", 1).strip()
+                 # Strip surrounding quotes
+                 proxy_cmd = proxy_cmd.strip('"').strip("'")
+             # Replace %h and %p placeholders with actual host/port
+             proxy_cmd = proxy_cmd.replace("%h", host).replace("%p", port)
+             connection_dict['sock'] = ProxyCommand(proxy_cmd)            
+        if not all(connection_dict.values()):
+            raise AnsibleError("Missing OcNOS connection details in inventory/task vars.")
+
+        result = {'changed': False, 'copied_files': [], 'failed': False}
+        
+        #Compile the Tech Support File Pattern
+        ts_file_pat = re.compile(r'\S+_tech_support.*')
+        
+        try:
+            # Try to establish a connection to the DUT using netmiko 
+            session = ConnectHandler(**connection_dict)
+            
+            #Enter into Debian Linux
+            session.enable()
+            session.send_command('start-shell',expect_string='$')
+            
+            #Privilege Escalation to root
+            session.send_command('su -', expect_string='Password:')
+            session.send_command('root', expect_string='#')
+            
+            #Change Directory to /var/log where Tech Support Files are stored
+            session.send_command('cd /var/log',expect_string='#',read_timeout=30)
+            
+            #Gather previous tech support files
+            output = session.send_command('ls')
+            
+            file_list = []
+            for files in output.split():
+                match = re.match(ts_file_pat, files)
+                if match:
+                     file_list.append(match.group())
+            
+            #clean up the files
+            if len(file_list) > 0:
+                for files in file_list:
+                    session.send_command(f'rm -f {files}')
+
+            session.send_command("cmlsh -e 'show techsupport all'")
+            state = 1
+            
+            result['copy_stat'] =''
+
+            #iterate to check the TS File status every 10 seconds for 10 attempts
+            for i in range(0,10):
+                ts_status = session.send_command("cmlsh -e 'show techsupport status'")
+                #Action block when TS File is completed
+                if 'Is Complete' in ts_status:
+                    output = session.send_command('ls')
+                    file_list = []
+                    for files in output.split():
+                        match = re.match(ts_file_pat, files)
+                        if match:
+                            file_list.append(match.group())
+                            if node_type == 'vm':
+                                copy_cmd = f'copy filepath /var/log/{file_list[0]} scp scp://{remote_username}:{remote_password}@{remote_host}{remote_path}/{file_list[0]}'
+                            else:
+
+                                copy_cmd = f'copy filepath /var/log/{file_list[0]} scp scp://{remote_username}:{remote_password}@{remote_host}{remote_path}/{file_list[0]} vrf management'
+                            session.send_command('exit',expect_string='$')
+                            session.send_command('exit',expect_string='#')
+                            output = session.send_command(copy_cmd, expect_string='#', read_timeout=60)
+                            state = 0
+                    #break from iterating loop
+                    break
+                else:
+                    #display.display('Still Waiting..')
+                    time.sleep(10)
+
+            if 'Failed' in output:
+                state = 1
+            
+            if state:
+                raise AnsibleError(f"Copy failed for {file_list[0]}: {output}")    
+            else:
+                result['copied_files'].append(file_list[0])
+                result['TS_File_Location'] = f'{remote_path}@{remote_host}'
+                result['copy_stat'] += output
+                result['changed'] = True
+        
+        except Exception as e:
+            raise AnsibleError(f"OcNOS TechSupport extraction failed: {str(e)}")
+        return result        

--- a/ipinfusion/ocnos/plugins/action/ocnos_validate.py
+++ b/ipinfusion/ocnos/plugins/action/ocnos_validate.py
@@ -1,0 +1,149 @@
+# Copyright (C) 2025 IP Infusion
+#
+# GNU General Public License v3.0+
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+#
+# Contains Action Plugin methods for OcNOS Validate Module
+# IP Infusion
+#
+
+DOCUMENTATION = '''
+---
+action: ocnos_validate
+short_description: Validate parsed CLI output against expected data
+version_added: "2.15"
+description:
+  - Compares expected parsed data with actual CLI output using TextFSM.
+  - Supports single or multiple key-based matching.
+options:
+  expected_data:
+    description: Dictionary or list of expected values to validate.
+    required: true
+    type: list
+  actual_data:
+    description: Parsed CLI output using TextFSM.
+    required: true
+    type: list
+author:
+  - Sharath Samanth (@yourhandle)
+'''
+
+EXAMPLES = '''
+- name: Validate interface state
+  ocnos_validate:
+    expected_data:
+      - interface: eth0
+        admin_state: up
+    actual_data: "{{ parsed_show_interface }}"
+'''
+
+RETURN = '''
+validated:
+  description: List of matched entries
+  type: list
+  returned: always
+mismatched:
+  description: List of entries that failed validation
+  type: list
+  returned: when mismatches occur
+'''
+from ansible.plugins.action import ActionBase
+from ansible.errors import AnsibleError
+
+
+class ActionModule(ActionBase):
+    def run(self, tmp=None, task_vars=None):
+        if task_vars is None:
+            task_vars = {}
+
+        expected_data = self._task.args.get('expected_data')
+        actual_data = self._task.args.get('actual_data')
+        match_key = self._task.args.get('match_key')
+        ignore_keys = self._task.args.get('ignore_keys', [])
+
+        if not isinstance(expected_data, list) or not isinstance(actual_data, list):
+            raise AnsibleError("Both expected_data and actual_data must be lists of dictionaries.")
+       
+        if not match_key:
+            raise AnsibleError("match_key is required for unordered comparison.")
+
+        # Check for single match_key, if yes then convert into list
+        if isinstance(match_key, str):
+            match_key = [match_key]
+
+        # Check for type of match_key to be list
+        if not isinstance(match_key, list):
+            raise AnsibleError("match_key must be a string or list of strings")
+
+        #composite key function
+        def make_key(item, key):
+            try:
+                return '|'.join([str(item[k]) for k in key])
+            except KeyError as e:
+                raise AnsibleError(f"Missing match_key '{e.args[0]}' in item: {item}")
+
+        # Build lookup for actual_data by match_key
+        actual_lookup = {}
+        for i, item in enumerate(actual_data):
+            if not isinstance(item, dict):
+                raise AnsibleError(f"Item {i} in actual_data is not a dictionary.")
+            #key = item.get(match_key)
+            key = make_key(item, match_key)
+            #if key is None:
+             #   raise AnsibleError(f"Item {i} in actual_data is missing match_key '{match_key}'.")
+            actual_lookup[key] = item
+
+        differences = []
+
+        for i, expected_item in enumerate(expected_data):
+            if not isinstance(expected_item, dict):
+                raise AnsibleError(f"Item {i} in expected_data is not a dictionary.")
+
+            #key = expected_item.get(match_key)
+            try:
+                key = make_key(expected_item, match_key)
+            #if key is None:
+             #   raise AnsibleError(f"Item {i} in expected_data is missing match_key '{match_key}'.")
+            except AnsibleError as e:
+                raise AnsibleError(f"Item {i} in expected_data error: {e}")
+
+            actual_item = actual_lookup.get(key)
+            if not actual_item:
+                differences.append({
+                    'key': key,
+                    'error': f"No matching item found in actual_data for {match_key}='{key}'"
+                })
+                continue
+
+            diff = {}
+            for k, expected_val in expected_item.items():
+                if k in ignore_keys:
+                    continue
+                actual_val = actual_item.get(k, '__missing__')
+                if actual_val != expected_val:
+                    diff[k] = {
+                        'expected': expected_val,
+                        'actual': actual_val
+                    }
+
+            if diff:
+                differences.append({
+                    'key': key,
+                    'differences': diff
+                })
+
+        return {
+            'changed': False,
+            'expected_data': expected_data,
+            'actual_data': actual_data,
+            'differences': differences,
+            'ignored_keys': ignore_keys,
+            'rc': 1 if differences else 0,
+        }
+


### PR DESCRIPTION
Hi Vince,

Please review and approve the below Ansible Action Plugins

## ocnos_config_backup
Action Plugin that copies OcNOS Running Configuration into a remote location.

## ocnos_config_restore
Action Plugin that copies a configuration file from remote location to OcNOS Startup configuration.

## ocnos_pcap
Action Plugin that Captures OcNOS Interface's control plane packets and copy into remote location.

## ocnos_sw_update
Action Plugin that updates the OcNOS Software using sys-update http method.

## ocnos_core_extract
Action Plugin that extracts crash files (Cores) and exports the GDB Log into remote location.

## ocnos_ts_extract
Action Plugin that extracts OcNOS TechSupport files and exports into remote location.

## ocnos_iperf3
Action Plugin that enables IPERF3 on OcNOS Devices either as a server or as a client.
This plugin is strictly for testing purposes and not recommended for Production Deployments.
OcNOS Rate Limits the CPU packets to 20Mbps

## ocnos_validate
Action Plugin that compares the Actual Output and the Expected Output of OcNOS Show commands.